### PR TITLE
northd, controller: Commit flows dropped by ACLs in a separate CT zone

### DIFF
--- a/.github/workflows/ovn-kubernetes.yml
+++ b/.github/workflows/ovn-kubernetes.yml
@@ -1,12 +1,6 @@
 name: ovn-kubernetes
 
-on:
-  push:
-  pull_request:
-  workflow_dispatch:
-  schedule:
-  # Run Sunday at midnight
-  - cron: '0 0 * * 0'
+on: []
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,6 @@
 name: Build and Test
 
-on:
-  push:
-  pull_request:
-  schedule:
-    # Run Sunday at midnight
-    - cron: '0 0 * * 0'
+on: []
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}

--- a/controller/ovn-controller.c
+++ b/controller/ovn-controller.c
@@ -662,8 +662,15 @@ update_ct_zones(const struct shash *binding_lports,
     unsigned long unreq_snat_zones[BITMAP_N_LONGS(MAX_CT_ZONES)];
 
     struct shash_node *shash_node;
+    const struct binding_lport *lport;
     SHASH_FOR_EACH (shash_node, binding_lports) {
         sset_add(&all_users, shash_node->name);
+
+        /* Zone for committing dropped connections of a vNIC. */
+        lport = shash_node->data;
+        char *drop_zone = alloc_ct_zone_key(&lport->pb->header_.uuid, "drop");
+        sset_add(&all_users, drop_zone);
+        free(drop_zone);
     }
 
     /* Local patched datapath (gateway routers) need zones assigned. */
@@ -671,8 +678,8 @@ update_ct_zones(const struct shash *binding_lports,
     HMAP_FOR_EACH (ld, hmap_node, local_datapaths) {
         /* XXX Add method to limit zone assignment to logical router
          * datapaths with NAT */
-        char *dnat = alloc_nat_zone_key(&ld->datapath->header_.uuid, "dnat");
-        char *snat = alloc_nat_zone_key(&ld->datapath->header_.uuid, "snat");
+        char *dnat = alloc_ct_zone_key(&ld->datapath->header_.uuid, "dnat");
+        char *snat = alloc_ct_zone_key(&ld->datapath->header_.uuid, "snat");
         sset_add(&all_users, dnat);
         sset_add(&all_users, snat);
 
@@ -2149,7 +2156,7 @@ ct_zones_datapath_binding_handler(struct engine_node *node, void *data)
         /* Check if the requested snat zone has changed for the datapath
          * or not.  If so, then fall back to full recompute of
          * ct_zone engine. */
-        char *snat_dp_zone_key = alloc_nat_zone_key(&dp->header_.uuid, "snat");
+        char *snat_dp_zone_key = alloc_ct_zone_key(&dp->header_.uuid, "snat");
         struct simap_node *simap_node = simap_find(&ct_zones_data->current,
                                                    snat_dp_zone_key);
         free(snat_dp_zone_key);
@@ -2207,6 +2214,16 @@ ct_zones_runtime_data_handler(struct engine_node *node, void *data)
                                         &ct_zones_data->pending);
                     updated = true;
                 }
+                char *drop_zone = alloc_ct_zone_key(
+                    &t_lport->pb->header_.uuid, "drop");
+                if (!simap_contains(&ct_zones_data->current, drop_zone)) {
+                    alloc_id_to_ct_zone(drop_zone,
+                                        &ct_zones_data->current,
+                                        ct_zones_data->bitmap, &scan_start,
+                                        &ct_zones_data->pending);
+                    updated = true;
+                }
+                free(drop_zone);
             } else if (t_lport->tracked_type == TRACKED_RESOURCE_REMOVED) {
                 struct simap_node *ct_zone =
                     simap_find(&ct_zones_data->current,

--- a/controller/ovn-controller.c
+++ b/controller/ovn-controller.c
@@ -668,7 +668,7 @@ update_ct_zones(const struct shash *binding_lports,
 
         /* Zone for committing dropped connections of a vNIC. */
         lport = shash_node->data;
-        if (smap_get(lport->pb->options, "commit-dropped-connections")) {
+        if (smap_get(&lport->pb->options, "commit-dropped-connections")) {
             char *drop_zone_key = alloc_ct_zone_key(&lport->pb->header_.uuid,
                                                     "drop");
             sset_add(&all_users, drop_zone_key);
@@ -2217,7 +2217,7 @@ ct_zones_runtime_data_handler(struct engine_node *node, void *data)
                                         &ct_zones_data->pending);
                     updated = true;
                 }
-                if (smap_get(t_lport->pb->options,
+                if (smap_get(&t_lport->pb->options,
                              "commit-dropped-connections")) {
                     char *drop_zone_key = alloc_ct_zone_key(
                         &t_lport->pb->header_.uuid, "drop");

--- a/controller/ovn-controller.c
+++ b/controller/ovn-controller.c
@@ -668,9 +668,12 @@ update_ct_zones(const struct shash *binding_lports,
 
         /* Zone for committing dropped connections of a vNIC. */
         lport = shash_node->data;
-        char *drop_zone = alloc_ct_zone_key(&lport->pb->header_.uuid, "drop");
-        sset_add(&all_users, drop_zone);
-        free(drop_zone);
+        if (smap_get(lport->pb->options, "commit-dropped-connections")) {
+            char *drop_zone_key = alloc_ct_zone_key(&lport->pb->header_.uuid,
+                                                    "drop");
+            sset_add(&all_users, drop_zone_key);
+            free(drop_zone_key);
+        }
     }
 
     /* Local patched datapath (gateway routers) need zones assigned. */
@@ -2214,16 +2217,21 @@ ct_zones_runtime_data_handler(struct engine_node *node, void *data)
                                         &ct_zones_data->pending);
                     updated = true;
                 }
-                char *drop_zone = alloc_ct_zone_key(
-                    &t_lport->pb->header_.uuid, "drop");
-                if (!simap_contains(&ct_zones_data->current, drop_zone)) {
-                    alloc_id_to_ct_zone(drop_zone,
-                                        &ct_zones_data->current,
-                                        ct_zones_data->bitmap, &scan_start,
-                                        &ct_zones_data->pending);
-                    updated = true;
+                if (smap_get(t_lport->pb->options,
+                             "commit-dropped-connections")) {
+                    char *drop_zone_key = alloc_ct_zone_key(
+                        &t_lport->pb->header_.uuid, "drop");
+                    if (!simap_contains(&ct_zones_data->current, drop_zone_key)) {
+                        alloc_id_to_ct_zone(drop_zone_key,
+                                            &ct_zones_data->current,
+                                            ct_zones_data->bitmap,
+                                            &scan_start,
+                                            &ct_zones_data->pending);
+                        updated = true;
+                    }
+                    free(drop_zone_key);
                 }
-                free(drop_zone);
+                
             } else if (t_lport->tracked_type == TRACKED_RESOURCE_REMOVED) {
                 struct simap_node *ct_zone =
                     simap_find(&ct_zones_data->current,
@@ -2237,6 +2245,21 @@ ct_zones_runtime_data_handler(struct engine_node *node, void *data)
                     simap_delete(&ct_zones_data->current, ct_zone);
                     updated = true;
                 }
+
+                char *drop_zone_key = alloc_ct_zone_key(
+                        &t_lport->pb->header_.uuid, "drop");
+                ct_zone = simap_find(&ct_zones_data->current,
+                                     drop_zone_key);
+                if (ct_zone) {
+                    add_pending_ct_zone_entry(
+                        &ct_zones_data->pending, CT_ZONE_OF_QUEUED,
+                        ct_zone->data, false, ct_zone->name);
+
+                    bitmap_set0(ct_zones_data->bitmap, ct_zone->data);
+                    simap_delete(&ct_zones_data->current, ct_zone);
+                    updated = true;
+                }
+                free(drop_zone_key);
             }
         }
     }

--- a/controller/physical.c
+++ b/controller/physical.c
@@ -60,6 +60,7 @@ struct zone_ids {
     int ct;                     /* MFF_LOG_CT_ZONE. */
     int dnat;                   /* MFF_LOG_DNAT_ZONE. */
     int snat;                   /* MFF_LOG_SNAT_ZONE. */
+    int drop;                   /* MFF_LOG_ACL_DROP_ZONE. */
 };
 
 struct tunnel {
@@ -204,13 +205,17 @@ get_zone_ids(const struct sbrec_port_binding *binding,
 
     const struct uuid *key = &binding->datapath->header_.uuid;
 
-    char *dnat = alloc_nat_zone_key(key, "dnat");
+    char *dnat = alloc_ct_zone_key(key, "dnat");
     zone_ids.dnat = simap_get(ct_zones, dnat);
     free(dnat);
 
-    char *snat = alloc_nat_zone_key(key, "snat");
+    char *snat = alloc_ct_zone_key(key, "snat");
     zone_ids.snat = simap_get(ct_zones, snat);
     free(snat);
+
+    char *drop_zone = alloc_ct_zone_key(&binding->header_.uuid, "drop");
+    zone_ids.drop = simap_get(ct_zones, drop_zone);
+    free(drop_zone);
 
     return zone_ids;
 }
@@ -830,6 +835,9 @@ put_zones_ofpacts(const struct zone_ids *zone_ids, struct ofpbuf *ofpacts_p)
         if (zone_ids->snat) {
             put_load(zone_ids->snat, MFF_LOG_SNAT_ZONE, 0, 32, ofpacts_p);
         }
+        if (zone_ids->drop) {
+            put_load(zone_ids->drop, MFF_LOG_ACL_DROP_ZONE, 0, 32, ofpacts_p);
+        }
     }
 }
 
@@ -865,6 +873,26 @@ put_local_common_flows(uint32_t dp_key,
     ofctrl_add_flow(flow_table, OFTABLE_LOCAL_OUTPUT, 100,
                     pb->header_.uuid.parts[0], &match, ofpacts_p,
                     &pb->header_.uuid);
+
+    if (zone_ids->drop) {
+        /* Table 39, Priority 1.
+         * =======================
+         *
+         * Clear the logical registers (for consistent behavior with packets
+         * that get tunneled) except MFF_LOG_ACL_DROP_ZONE. */
+        match_init_catchall(&match);
+        ofpbuf_clear(ofpacts_p);
+        match_set_metadata(&match, htonll(dp_key));
+        for (int i = 0; i < MFF_N_LOG_REGS; i++) {
+            if ((MFF_REG0 + i) != MFF_LOG_ACL_DROP_ZONE) {
+                put_load(0, MFF_REG0 + i, 0, 32, ofpacts_p);
+            }
+        }
+        put_resubmit(OFTABLE_LOG_EGRESS_PIPELINE, ofpacts_p);
+        ofctrl_add_flow(flow_table, OFTABLE_CHECK_LOOPBACK, 1,
+                        pb->datapath->header_.uuid.parts[0], &match,
+                        ofpacts_p, &pb->datapath->header_.uuid);
+    }
 
     /* Table 39, Priority 100.
      * =======================

--- a/controller/physical.c
+++ b/controller/physical.c
@@ -213,9 +213,9 @@ get_zone_ids(const struct sbrec_port_binding *binding,
     zone_ids.snat = simap_get(ct_zones, snat);
     free(snat);
 
-    char *drop_zone = alloc_ct_zone_key(&binding->header_.uuid, "drop");
-    zone_ids.drop = simap_get(ct_zones, drop_zone);
-    free(drop_zone);
+    char *drop_zone_key = alloc_ct_zone_key(&binding->header_.uuid, "drop");
+    zone_ids.drop = simap_get(ct_zones, drop_zone_key);
+    free(drop_zone_key);
 
     return zone_ids;
 }

--- a/include/ovn/actions.h
+++ b/include/ovn/actions.h
@@ -121,6 +121,7 @@ struct ovn_extend_table;
     OVNACT(COMMIT_ECMP_NH,    ovnact_commit_ecmp_nh)  \
     OVNACT(CHK_ECMP_NH_MAC,   ovnact_result)          \
     OVNACT(CHK_ECMP_NH,       ovnact_result)          \
+    OVNACT(CT_COMMIT_DROP,    ovnact_nest)            \
 
 /* enum ovnact_type, with a member OVNACT_<ENUM> for each action. */
 enum OVS_PACKED_ENUM ovnact_type {

--- a/include/ovn/logical-fields.h
+++ b/include/ovn/logical-fields.h
@@ -47,6 +47,7 @@ enum ovn_controller_event {
 #define MFF_LOG_REG0             MFF_REG0
 #define MFF_LOG_LB_ORIG_DIP_IPV4 MFF_REG1
 #define MFF_LOG_LB_ORIG_TP_DPORT MFF_REG2
+#define MFF_LOG_ACL_DROP_ZONE    MFF_REG8
 
 #define MFF_LOG_XXREG0           MFF_XXREG0
 #define MFF_LOG_LB_ORIG_DIP_IPV6 MFF_XXREG1

--- a/lib/ovn-util.c
+++ b/lib/ovn-util.c
@@ -443,12 +443,12 @@ split_addresses(const char *addresses, struct svec *ipv4_addrs,
     destroy_lport_addresses(&laddrs);
 }
 
-/* Allocates a key for NAT conntrack zone allocation for a provided
+/* Allocates a key for conntrack zone allocation for a provided
  * 'key' record and a 'type'.
  *
  * It is the caller's responsibility to free the allocated memory. */
 char *
-alloc_nat_zone_key(const struct uuid *key, const char *type)
+alloc_ct_zone_key(const struct uuid *key, const char *type)
 {
     return xasprintf(UUID_FMT"_%s", UUID_ARGS(key), type);
 }

--- a/lib/ovn-util.h
+++ b/lib/ovn-util.h
@@ -92,7 +92,7 @@ const char *find_lport_address(const struct lport_addresses *laddrs,
 void split_addresses(const char *addresses, struct svec *ipv4_addrs,
                      struct svec *ipv6_addrs);
 
-char *alloc_nat_zone_key(const struct uuid *key, const char *type);
+char *alloc_ct_zone_key(const struct uuid *key, const char *type);
 
 const char *default_nb_db(void);
 const char *default_sb_db(void);

--- a/northd/northd.c
+++ b/northd/northd.c
@@ -287,7 +287,7 @@ enum ovn_stage {
  * +----+----------------------------------------------+ G |                  |
  * | R7 |                   UNUSED                     | 1 |                  |
  * +----+----------------------------------------------+---+------------------+
- * | R8 |                   UNUSED                     |
+ * | R8 |        DROP_CT_ZONE (<= IN(/OUT)_ACL         |
  * +----+----------------------------------------------+
  * | R9 |                   UNUSED                     |
  * +----+----------------------------------------------+
@@ -6378,6 +6378,11 @@ consider_acl(struct hmap *lflows, struct ovn_datapath *od,
             } else {
                 ds_put_format(match, " && (%s)", acl->match);
                 build_acl_log(actions, acl, meter_groups);
+                if (acl->label) {
+                    ds_put_format(actions, "ct_commit_drop { "
+                                  "ct_label.label = %"PRId64"; }; ",
+                                  acl->label);
+                }
                 ds_put_cstr(actions, "/* drop */");
                 ovn_lflow_add_with_hint(lflows, od, stage,
                                         acl->priority + OVN_ACL_PRI_OFFSET,
@@ -6398,8 +6403,13 @@ consider_acl(struct hmap *lflows, struct ovn_datapath *od,
             ds_clear(match);
             ds_clear(actions);
             ds_put_cstr(match, REGBIT_ACL_HINT_BLOCK " == 1");
-            ds_put_format(actions, "ct_commit { %s = 1; }; ",
+            ds_put_format(actions, "ct_commit { %s = 1; ",
                           ct_blocked_match);
+            if (acl->label) {
+                ds_put_format(actions, "ct_label.label = %"PRId64"; ",
+                              acl->label);
+            }
+            ds_put_cstr(actions, "}; ");
             if (!strcmp(acl->action, "reject")) {
                 build_reject_acl_rules(od, lflows, stage, acl, match,
                                        actions, &acl->header_, meter_groups);

--- a/northd/northd.c
+++ b/northd/northd.c
@@ -3465,7 +3465,7 @@ ovn_port_update_sbrec(struct northd_input *input_data,
 
             const char *router_port = smap_get(&op->nbsp->options,
                                                "router-port");
-            if (router_port || chassis || op->od->has_label_drop_acl) {
+            if (router_port || chassis) {
                 struct smap new;
                 smap_init(&new);
                 if (router_port) {
@@ -3473,9 +3473,6 @@ ovn_port_update_sbrec(struct northd_input *input_data,
                 }
                 if (chassis) {
                     smap_add(&new, "l3gateway-chassis", chassis);
-                }
-                if (op->od->has_label_drop_acl) {
-                    smap_add(&new, "commit-dropped-connections", "true");
                 }
                 sbrec_port_binding_set_options(op->sb, &new);
                 smap_destroy(&new);
@@ -5481,7 +5478,6 @@ ls_get_acl_flags(struct ovn_datapath *od)
 {
     od->has_acls = false;
     od->has_stateful_acl = false;
-    od->has_label_drop_acl = false;
 
 
     if (od->nbs->n_acls) {
@@ -5491,11 +5487,6 @@ ls_get_acl_flags(struct ovn_datapath *od)
             struct nbrec_acl *acl = od->nbs->acls[i];
             if (!strcmp(acl->action, "allow-related")) {
                 od->has_stateful_acl = true;
-            }
-            if (acl->label && !strcmp(acl->action, "drop")) {
-                od->has_label_drop_acl = true;
-            }
-            if (od->has_stateful_acl && od->has_label_drop_acl) {
                 return;
             }
         }
@@ -5510,11 +5501,6 @@ ls_get_acl_flags(struct ovn_datapath *od)
                 struct nbrec_acl *acl = ls_pg->nb_pg->acls[i];
                 if (!strcmp(acl->action, "allow-related")) {
                     od->has_stateful_acl = true;
-                }
-                if (acl->label && !strcmp(acl->action, "drop")) {
-                    od->has_label_drop_acl = true;
-                }
-                if (od->has_stateful_acl && od->has_label_drop_acl) {
                     return;
                 }
             }

--- a/northd/northd.h
+++ b/northd/northd.h
@@ -209,6 +209,7 @@ struct ovn_datapath {
     bool has_unknown;
     bool has_acls;
     bool has_vtep_lports;
+    bool has_label_drop_acl;
 
     /* IPAM data. */
     struct ipam_info ipam_info;

--- a/northd/northd.h
+++ b/northd/northd.h
@@ -209,7 +209,6 @@ struct ovn_datapath {
     bool has_unknown;
     bool has_acls;
     bool has_vtep_lports;
-    bool has_label_drop_acl;
 
     /* IPAM data. */
     struct ipam_info ipam_info;

--- a/northd/ovn-northd.8.xml
+++ b/northd/ovn-northd.8.xml
@@ -695,7 +695,12 @@
         connections and <code>ct_commit(ct_label=1/1);</code> for known
         connections.  Setting <code>ct_label</code> marks a connection
         as one that was previously allowed, but should no longer be
-        allowed due to a policy change.
+        allowed due to a policy change. If the ACL has a <code>label</code>,
+        then it translates to
+        <code>ct_commit_drop(ct_label.label=label)</code> for new and
+        untracked connections and
+        <code>ct_commit(ct_label.blocked=1; ct_label.label=label);</code>
+        for known connections.
       </li>
     </ul>
 
@@ -965,7 +970,12 @@
         or untracked connections and <code>ct_commit(ct_label=1/1);</code> for
         known connections.  Setting <code>ct_label</code> marks a connection
         as one that was previously allowed, but should no longer be
-        allowed due to a policy change.
+        allowed due to a policy change. If the ACL has a <code>label</code>,
+        then it translates to
+        <code>ct_commit_drop(ct_label.label=label)</code> for new and
+        untracked connections and
+        <code>ct_commit(ct_label.blocked=1; ct_label.label=label);</code>
+        for known connections.
       </li>
     </ul>
 

--- a/ovn-sb.xml
+++ b/ovn-sb.xml
@@ -1377,6 +1377,23 @@
           </p>
         </dd>
 
+        <dt><code>ct_commit_drop { };</code></dt>
+        <dt><code>ct_commit_drop { ct_mark=<var>value[/mask]</var>; };</code></dt>
+        <dt><code>ct_commit_drop { ct_label=<var>value[/mask]</var>; };</code></dt>
+        <dt><code>ct_commit_drop { ct_mark=<var>value[/mask]</var>; ct_label=<var>value[/mask]</var>; };</code></dt>
+        <dd>
+          <p>
+            This action is identical to <code>ct_commit</code> except that the
+            connection tracking entry is committed in a different zone.
+          </p>
+
+          <p>
+            This action was added to store connections dropped by ACLs in a
+            separate zone that is managed independently of the
+            <code>ct_commit</code> zone, for debugging.
+          </p>
+        </dd>
+
         <dt><code>ct_dnat;</code></dt>
         <dt><code>ct_dnat(<var>IP</var>);</code></dt>
         <dd>

--- a/utilities/ovn-nbctl.c
+++ b/utilities/ovn-nbctl.c
@@ -2225,10 +2225,11 @@ nbctl_acl_add(struct ctl_context *ctx)
     /* Set the ACL label */
     const char *label = shash_find_data(&ctx->options, "--label");
     if (label) {
-      /* Ensure that the action is either allow or allow-related */
-      if (strcmp(action, "allow") && strcmp(action, "allow-related")) {
+      /* Ensure that the action is either allow or allow-related or drop */
+      if (strcmp(action, "allow") && strcmp(action, "allow-related") &&
+          strcmp(action, "drop")) {
         ctl_error(ctx, "label can only be set with actions \"allow\" or "
-                  "\"allow-related\"");
+                  "\"allow-related\" or \"drop\"");
         return;
       }
 


### PR DESCRIPTION
To identify connections dropped by ACLs, users can enable logging for ACLs but this approach does not scale. ACL logging uses "controller" action which causes a significant spike in the CPU usage of ovs-vswitchd (and ovn-controller to a lesser extent) even with metering enabled (observed 65% ovs-vswitchd CPU usage for logging 1000 packets per second). Another approach is to use drop sampling (patch by Adrian Moreno currently in review) but we might miss specific connections of interest with this approach.

This patch commits connections dropped by ACLs to the connection tracking table with a specific ACL label that was introduced in 0e0228be ( northd: Add ACL label). The dropped connections are committed in a separate CT zone so that they can be managed independently.

Each logical port is assigned a new zone for committing dropped flows. The zone is loaded into register MFF_LOG_ACL_DROP_ZONE.

A new lflow action "ct_commit_drop" is introduced that commits flows to connection tracking table in a zone identified by MFF_LOG_ACL_DROP_ZONE register.

An ACL with "drop" action and non-empty label is translated to "ct_commit_drop" instead of silently dropping the packet.